### PR TITLE
Stop build if externals don't receive correct params

### DIFF
--- a/jenkins/jk-setup.sh
+++ b/jenkins/jk-setup.sh
@@ -13,7 +13,7 @@ if [ $# -ge 4 ]; then
   EXTERNALS=$1 ; shift
 else
   echo "$0: expecting 4 arguments [LABEL]  [COMPILER] [BUILDTYPE] [EXTERNALS]"
-  return
+  exit 1
 fi
 
 export BUILDTYPE


### PR DESCRIPTION
If there is a typo, or a missing env variable, the build process continues although it fails loading the externals. This patch stops the build at this step, exiting with status code 1.