### PR TITLE
Pipeline support

### DIFF
--- a/jenkins/jk-all
+++ b/jenkins/jk-all
@@ -49,23 +49,26 @@ then
 
 else
 
-    ctest -VV -S ${THIS}/root-build.cmake
-    status=$?
+    if [[ "$1" != "test" ]]; then 
+        ctest -VV -S ${THIS}/root-build.cmake
+        status=$?
 
-    # do not run the tests if continous build fails
-    if [ $status -ne 0 ] && [ "$MODE" = continuous ]; then
-       exit $status
+        # do not run the tests if continous build fails
+        if [ $status -ne 0 ] && [ "$MODE" = continuous ]; then
+            exit $status
+        fi
+
+        # do not run tests if coverity run
+        if [ "$BUILDOPTS" == coverity ]; then
+            exit $status
+        fi
     fi
 
-    # do not run tests if coverity run
-    if [ "$BUILDOPTS" == coverity ]; then
-       exit $status
+    if [[ "$1" != "build" ]]; then 
+        ctest -V -S ${THIS}/root-test.cmake
+        status=$?
     fi
-
-    ctest -V -S ${THIS}/root-test.cmake
-    status=$?
 fi
 
 exit $status
-
 

--- a/jenkins/logparser-rules/ROOT-incremental-LogParserRules.txt
+++ b/jenkins/logparser-rules/ROOT-incremental-LogParserRules.txt
@@ -1,0 +1,51 @@
+
+ok /not really/
+ok /^make\[[[:digit:]]+\]: [*][*][*] \[.*[.]test. Error [[:digit:]]+$/
+ok /^make\[[[:digit:]]+\]: Target `test. not remade because of errors.$/
+
+
+# match line starting with 'error ', case-insensitive
+error /(?i)^error /
+error /(?i)^error: /
+error /\[ERROR\]/
+error /\[FATAL\]/
+error / FAILED /
+error /: error:/
+error /MSBUILD : error MSB/
+
+
+# list of warnings here...
+warning /: warning:/
+warning /UNSTABLE/
+
+# create a quick access link to lines in the report containing 'INFO'
+info /INFO/
+
+# each line containing 'BUILD' represents the start of a section for grouping errors and warnings found after the line.
+# also creates a quick access link.
+
+ok /not really/
+ok /^make\[[[:digit:]]+\]: [*][*][*] \[.*[.]test. Error [[:digit:]]+$/
+ok /^make\[[[:digit:]]+\]: Target `test. not remade because of errors.$/
+
+
+# match line starting with 'error ', case-insensitive
+error /(?i)^error /
+error /(?i)^error: /
+error /\[ERROR\]/
+error /\[FATAL\]/
+error / FAILED /
+error /: error:/
+error /MSBUILD : error MSB/
+
+
+# list of warnings here...
+warning /: warning:/
+warning /UNSTABLE/
+
+# create a quick access link to lines in the report containing 'INFO'
+info /INFO/
+
+# each line containing 'BUILD' represents the start of a section for grouping errors and warnings found after the line.
+# also creates a quick access link.
+


### PR DESCRIPTION
This PR enables providing a flag to jk-all for selecting if the build process should either compile or test. If no extra flag is supplied, the build process will first build then run tests. Example:
`jk-all build` : Builds
`jk-all test` : Runs tests
`jk-all` : Builds, then tests
The log parser rules has also been moved to a subdirectory under jenkins/logparser-rules.