### PR TITLE
Specify c++-version through environment variable

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -23,6 +23,12 @@ if("$ENV{BUILDOPTS}" STREQUAL "cxx14root7")
   set(options ${options} -Dcxx14=ON -Droot7=ON)
 endif()
 
+if("$ENV{CXX_VERSION}" STREQUAL "14")
+  set(options ${options} -Dcxx14=ON)
+elseif("$ENV{CXX_VERSION}" STREQUAL "17")
+  set(options ${options} -Dcxx17=ON)
+endif()
+
 if("$ENV{BUILDOPTS}" STREQUAL "cxxmodules" OR
    "$ENV{BUILDOPTS}" STREQUAL "coverity")
   unset(CTEST_CHECKOUT_COMMAND)


### PR DESCRIPTION
In order to specify the c++-version on an axis in Jenkins, it has to be enabled through an environment variable instead of through the extra cmake flags. This PR provides this through the environment variable `CXX_VERSION`.