### PR TITLE
Add support for Ubuntu 16.04 Docker distribution

### DIFF
--- a/docker/ubuntu16-base/Dockerfile
+++ b/docker/ubuntu16-base/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install \
+             make g++ gcc cmake git libx11-dev libxpm-dev libxft-dev libxext-dev python lsb-release locales libxml2-dev python-dev libgsl0-dev ccache \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -1,0 +1,6 @@
+FROM rootproject/root-ubuntu16-base
+
+ADD build.sh /
+ENV PATH="/usr/local/root/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/root/lib/root"
+

--- a/docker/ubuntu16/build.sh
+++ b/docker/ubuntu16/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+if [ $# -ge 4 ]; then
+  LABEL=$1 ; shift
+  COMPILER=$1 ; shift
+  BUILDTYPE=$1 ; shift
+  BRANCH=$1 ; shift
+else
+  echo "$0: expecting 4 arguments [LABEL] [COMPILER] [BUILDTYPE] [BRANCH]"
+  exit 1
+fi
+
+# Setup build env
+cd /root-build
+
+export CCACHE_DIR=/ccache
+export JENKINS_HOME=/tmp
+export EXTERNALS=docker
+
+export MODE=experimental
+export ExtraCMakeOptions='-Dccache=ON -DCMAKE_INSTALL_PREFIX=/usr/local -Dgnuinstall=ON'
+
+export LABEL
+export COMPILER
+export BUILDTYPE
+
+# Build
+rootspi/jenkins/jk-all build
+# Install
+cmake -P build/cmake_install.cmake
+# Test
+rootspi/jenkins/jk-all test
+# Stash test reports and cleanup
+rm -rf Testing
+cp -r build/Testing Testing
+rm -rf build


### PR DESCRIPTION
This PR adds support for building ROOT in a Docker container that is pushed to Dockerhub. The script that initializes this is [DockerDeployUbuntu.groovy](https://github.com/root-project/jenkins-pipelines/blob/master/DockerDeployUbuntu.groovy). The two jobs set up for it on Jenkins is [root-docker-snapshot](https://epsft-jenkins.cern.ch/view/ROOT/job/root-docker-snapshot/) and [root-docker-6-10-patches](https://epsft-jenkins.cern.ch/view/ROOT/job/root-docker-v6-10-00-patches/).