### PR TITLE
Don't add PATH and set correct LD_LIBRARY_PATH in container

### DIFF
--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -1,6 +1,5 @@
 FROM rootproject/root-ubuntu16-base
 
 ADD build.sh /
-ENV PATH="/usr/local/root/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/root/lib/root"
 

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -1,5 +1,5 @@
 FROM rootproject/root-ubuntu16-base
 
 ADD build.sh /
-ENV LD_LIBRARY_PATH="/usr/local/root/lib/root"
+ENV LD_LIBRARY_PATH="/usr/local/lib/root"
 


### PR DESCRIPTION
The PATH is no longer needed to be set after ROOT is installed to /usr/local/. The LD_LIBRARY_PATH is also updated to correspond to the right location of library files.