### PR TITLE
Avoid using non-existent group for user

### DIFF
--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -7,5 +7,5 @@ ARG uid
 RUN useradd --create-home --home-dir /home/sftnight/ --uid ${uid} --groups sudo sftnight && \
     passwd --delete sftnight
 
-USER sftnight
+USER sftnight:sftnight
 ENV HOME /home/sftnight


### PR DESCRIPTION
Mentioned in #25, removes warning.