### PR TITLE
Correctly specify python2 for getPlatform.py

### DIFF
--- a/jenkins/getPlatform.py
+++ b/jenkins/getPlatform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os, platform, string, re
 
 arch = platform.machine()


### PR DESCRIPTION
Right now we fail to source setup.sh here when python 3 is the default for the system. This for example happens with Guilherme's CVMFS Gentoo installation (that sadly has the only working gdb instance that one can use). So we explicitly have to state that this is python2 code that doesn't work with python3.