### PR TITLE
Give a python 2 script with a python2 shebang

### DIFF
--- a/jenkins/getPlatform.py
+++ b/jenkins/getPlatform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os, platform, string, re
 
 arch = platform.machine()


### PR DESCRIPTION
Otherwise this fails on systems that have python3 by default and
can't parse this python2 only script.