### PR TITLE
Clang build on Ubuntu can be used on Ubuntu and not centos7

### DIFF
--- a/jenkins/jk-setup.sh
+++ b/jenkins/jk-setup.sh
@@ -38,12 +38,19 @@ fi
 if [[ $LABEL == *centos7-clangHEAD ]]; then
   # We use clang as a compiler with libstdc++.
   # Get the gcc version. First parameter is a zero-based offset and the second is the length.
-  . /cvmfs/sft.cern.ch/lcg/contrib/gcc/7.3.0/x86_64-centos7-gcc7-opt/setup.sh
+  #. /cvmfs/sft.cern.ch/lcg/contrib/gcc/7.3.0/x86_64-centos7-gcc7-opt/setup.sh
+  export PATH=/cvmfs/sft.cern.ch/lcg/contrib/llvm/latest/x86_64-centos7-gcc48-opt/bin/:$PATH
+  export CC=`which clang`
+  export CXX=`which clang++`
+  # On centos7 + gcc52/gcc62 we want to compile with a more 'standard' toolchain.
+  #export ExtraCMakeOptions="${ExtraCMakeOptions} -Dgcctoolchain=$(dirname $(dirname `which gcc`))"
+fi
+
+if [[ $LABEL == *ubuntu1804-clangHEAD ]]; then
+  # We use clang as a compiler with libstdc++.
   export PATH=/cvmfs/sft.cern.ch/lcg/contrib/llvm/latest/x86_64-ubuntu1804-gcc7-opt/bin/:$PATH
   export CC=`which clang`
   export CXX=`which clang++`
-  # On centos7 we want to compile with a more 'standard' toolchain.
-  export ExtraCMakeOptions="${ExtraCMakeOptions} -Dgcctoolchain=$(dirname $(dirname `which gcc`))"
 fi
 
 # Special settings for Clang HEAD and for ROOT-patched LLVM/Clang builds


### PR DESCRIPTION
Otherwise we get warnings about libtinfo: clang++: /lib64/libtinfo.so.5: no version information available (it is breaking a lot of references in tests)