### PR TITLE
Revert "Change clang HEAD compiler (LLVM head is now requiring host c…

### DIFF
--- a/jenkins/rootbench/jk-setup-rootbench.sh
+++ b/jenkins/rootbench/jk-setup-rootbench.sh
@@ -83,7 +83,7 @@ elif [[ $COMPILER == clang_gcc* ]]; then
       . /cvmfs/sft.cern.ch/lcg/contrib/gcc/${GCCversion}/${ARCH}-${LABEL}/setup.sh
   fi
 
-  export PATH=/cvmfs/sft.cern.ch/lcg/contrib/llvm/latest/x86_64-ubuntu1804-gcc7-opt/bin/:$PATH
+  export PATH=/cvmfs/sft.cern.ch/lcg/contrib/llvm/latest/x86_64-centos7-gcc48-opt/bin/:$PATH
   export CC=`which clang`
   export CXX=`which clang++`
   export ExtraCMakeOptions="${ExtraCMakeOptions} -Dfortran=OFF -Darrow=OFF"


### PR DESCRIPTION
…ompiler version at least 5.1)"

Ubuntu clang-head build doesn't work correctly on centos7. Temporary fixed with -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=On

This reverts commit 3c01a0de7eb7e79ec7fe18104365ee21a7a09a03.