### PR TITLE
Revert "Re-add Pythia8 to all supported modules configuration setup"

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -96,7 +96,6 @@ function(GET_ALL_SUPPORTED_MODULES_WIN32)
     table
     thread
     vmc
-    pythia8
   )
 
   set(package_builtins


### PR DESCRIPTION
Pythia8 can't be enabled on Windows node..

14:19:34 -- Looking for Pythia8
14:19:37 -- Could NOT find Pythia8 (missing: PYTHIA8_INCLUDE_DIR PYTHIA8_LIBRARY) 
14:19:37 CMake Error at cmake/modules/SearchInstalledSoftware.cmake:670 (message):
14:19:37   Pythia8 libraries not found and they are required (pythia8 option enabled)
14:19:37 Call Stack (most recent call first):
14:19:37   CMakeLists.txt:165 (include)

This reverts commit bf524ba3147339f3bbf2be67fbbb7c77bff8b327.