### PR TITLE
only enable io_uring tests on Fedora 32

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -514,6 +514,11 @@ function(GET_ALL_SUPPORTED_MODULES_LINUX)
     EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_JUPYTER_PY3)
   endif()
 
+  # Fedora 32 is the dedicated liburing test environment
+  if("${LABEL}" MATCHES "fedora32")
+    EXPORT_CTEST_ENVVAR(ROOTTEST_ENABLE_URING)
+  endif()
+
   # Fedora 32 upwards have python2 completely deprecated, also installation of python2-pip is
   # not possible via dnf.
   if("${LABEL}" MATCHES "fedora32|centos8")

--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -515,8 +515,8 @@ function(GET_ALL_SUPPORTED_MODULES_LINUX)
   endif()
 
   # Fedora 32 is the dedicated liburing test environment
-  if("${LABEL}" MATCHES "fedora32")
-    EXPORT_CTEST_ENVVAR(ROOTTEST_ENABLE_URING)
+  if(NOT "${LABEL}" MATCHES "fedora32")
+    EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_URING)
   endif()
 
   # Fedora 32 upwards have python2 completely deprecated, also installation of python2-pip is


### PR DESCRIPTION
Only test `io_uring` features on the Fedora 32 node (see discussion on the main build system PR here: https://github.com/root-project/root/pull/5919#discussion_r462186345)

**Edit:** switched from explicit enable to explicit disable in commit 0ca38b6, i.e. 

```cmake
if(uring AND NOT DEFINED ENV{ROOTTEST_IGNORE_URING})
  ROOT_ADD_GTEST(RIoUring RIoUring.cxx LIBRARIES RIO uring)
endif()
```
Instead of the first approach: 
```cmake
if(uring AND DEFINED ENV{ROOTTEST_ENABLE_URING})
  ROOT_ADD_GTEST(RIoUring RIoUring.cxx LIBRARIES RIO uring)
endif()
```

which had the disadvantage of forcing the uring feature developer to define `ROOTTEST_ENABLE_URING` if the development environment was not `fedora32`. 