### PR TITLE
[python][macos] veto numba for mac10beta

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -277,6 +277,13 @@ function(GET_ALL_SUPPORTED_MODULES_APPLE)
   EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_NUMBA_PY2)
   EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_JUPYTER_PY2)
 
+  # We cannot install numba on mac10beta because pip does not yet distribute binaries
+  # for llvmlite and building the wheel locally also fails.
+  # NOTE: To be removed once the OS is officially released
+  if("${LABEL}" MATCHES "mac10beta")
+    EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_NUMBA_PY3)
+  endif()
+
   set(all_supported ${all_supported} PARENT_SCOPE)
   set(package_builtins ${package_builtins} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
We cannot install llvmlite required by numba because there are not yet
any binaries and building the wheel locally also fails.