### PR TITLE
Small typo in i386 label

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -561,7 +561,7 @@ function(GET_ALL_SUPPORTED_MODULES_LINUX)
   endif()
 
   # pyspark not supported on these labels
-  if("${LABEL}" MATCHES "i386|centos7|multicore|ubuntu1[46]")
+  if("${LABEL}" MATCHES "-i386|centos7|multicore|ubuntu1[46]")
     EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_PYSPARK_PY3)
     EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_PYSPARK_PY2)
   endif()


### PR DESCRIPTION
Seems that without this "-" sign the label isn't picked correctly so the variable is not written to the file:
```
sftnight@pcepsft10:~/build/workspace/root-pullrequests-build/build$ cat CTestEnvVars.cmake 
set(ENV{ROOTTEST_IGNORE_URING} TRUE)
set(ENV{ROOTTEST_IGNORE_NUMBA_PY2} TRUE)
sftnight@pcepsft10:~/build/workspace/root-pullrequests-build/build$ hostname
pcepsft10
```