### PR TITLE
Make sure the PyROOT options of MacOS12 release builds are the same as in the nightlies

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -898,7 +898,7 @@ function(CONFIGURE_ROOT_OPTIONS)
   endif()
 
   #---No OS Python3 on MacOS--------------------------------------------------
-  if(APPLE AND CTEST_MODE STREQUAL package)
+  if(APPLE AND CTEST_MODE STREQUAL package AND NOT CTEST_VERSION STREQUAL "master")
     set(pythonexe_options -DPYTHON_EXECUTABLE=/usr/bin/python)
   endif()
 

--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -248,6 +248,12 @@ function(GET_ALL_SUPPORTED_MODULES_APPLE)
     )
   endif()
 
+  if("${LABEL}" MATCHES "mac12" AND CTEST_VERSION STREQUAL "master")
+    list(APPEND all_supported
+      pyroot3 # To make mac12 master release builds have the same pyroot3 option as nightlies
+    )
+  endif()
+
   set(package_builtins
     builtin_afterimage
     builtin_cfitsio


### PR DESCRIPTION
The goal of these changes is to test the assumption that the following errors on the release build of MacOS12:

https://lcgapp-services.cern.ch/root-jenkins/view/Releases/job/root-release-master/BUILDTYPE=Release,LABEL=mac12,V=master/690/parsed_console/

are due to the differences in the CMake PyROOT options with respect to the MacOS12 nightly builds:

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=mac12,SPEC=soversion,V=master/3076/consoleFull

which build just fine.

In particular, the main suspect is the setting of `PYTHON_EXECUTABLE`, but also `pyroot3` is set to `On` to have the same options as in the nightlies.