### PR TITLE
Disable Python3 Numba tests also on macOS12 ARM

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -290,11 +290,14 @@ function(GET_ALL_SUPPORTED_MODULES_APPLE)
 
   # We cannot install numba on some Macs because pip does not (yet) distribute binaries
   # for llvmlite and building the wheel locally also fails.
-  # Also installing pandas fails due to incompatibilities on this system with the numpy.
+  if("${LABEL}" MATCHES "mac11arm|mac10beta|mac12arm")
+    EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_NUMBA_PY3)
+  endif()
+
+  # Installing pandas fails due to incompatibilities with numpy on some macOS
   if("${LABEL}" MATCHES "mac11arm|mac10beta")
     EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_PANDAS_PY2)
     EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_PANDAS_PY3)
-    EXPORT_CTEST_ENVVAR(ROOTTEST_IGNORE_NUMBA_PY3)
   endif()
 
   set(all_supported ${all_supported} PARENT_SCOPE)


### PR DESCRIPTION
Because it is not possible at the moment to install numba with
pip on macOS12 on ARM.
https://github.com/numba/llvmlite/issues/693
https://github.com/numba/llvmlite/issues/799

I tried to install pandas and numpy on macphsft26 (macOS12 ARM) with the XCode Python and there were no issues, so I'm not disabling pandas on mac12arm as it is done with mac11arm and mac10beta.