### PR TITLE
Since 6.26, we release with XCode Python3 on MacOS11&12

### DIFF
--- a/jenkins/root-build.cmake
+++ b/jenkins/root-build.cmake
@@ -244,13 +244,11 @@ function(GET_ALL_SUPPORTED_MODULES_APPLE)
 
   if(NOT CTEST_MODE STREQUAL package)
     list(APPEND all_supported
-      pyroot3 # Can't release with non-"distro" Python3, but can test
+      pyroot3 # We can test with non-"distro" Python3
     )
-  endif()
-
-  if("${LABEL}" MATCHES "mac12" AND CTEST_VERSION STREQUAL "master")
+  elseif("${LABEL}" MATCHES "mac11|mac12" AND ROOT_VERSION VERSION_GREATER_EQUAL 6.26)
     list(APPEND all_supported
-      pyroot3 # To make mac12 master release builds have the same pyroot3 option as nightlies
+      pyroot3 # On mac11&12 we release against the XCode Python3 too, starting in v6.26
     )
   endif()
 
@@ -906,8 +904,8 @@ function(CONFIGURE_ROOT_OPTIONS)
     set(buildtype_option -A Win32 -Thost=x64 ${buildtype_option})
   endif()
 
-  #---No OS Python3 on MacOS--------------------------------------------------
-  if(APPLE AND CTEST_MODE STREQUAL package AND NOT CTEST_VERSION STREQUAL "master")
+  #---No OS Python3 on MacOS10------------------------------------------------
+  if("${LABEL}" MATCHES "mac10" AND CTEST_MODE STREQUAL package)
     set(pythonexe_options -DPYTHON_EXECUTABLE=/usr/bin/python)
   endif()
 


### PR DESCRIPTION
This PR readjusts some settings that were done to test the XCode Python3 on macOS12.

Now we want to test and release with the XCode Python3 on macOS11 and 12, starting from v6.26.