### PR TITLE
Un-define PYTHON

### DIFF
--- a/rdoc/makedoxy.sh
+++ b/rdoc/makedoxy.sh
@@ -44,22 +44,10 @@ rm -rf $docdir $dir/${docdir}_TMP
 # set HOME (used by doxygen/Makefile)
 export DOXYGEN_OUTPUT_DIRECTORY=$dir/${docdir}_TMP
 
-PYTHON=`which python` || true
-if ! [ -x "${PYTHON}" ]; then
-    PYTHON=`which python3` || true
-fi
-if ! [ -x "${PYTHON}" ]; then
-    PYTHON=`which python2` || true
-fi
-if ! [ -x "${PYTHON}" ]; then
-    echo 'ERROR: cannot find python, python3, nor python2!'
-    exit 1
-fi
-
 # make doxygen
 if [ -d $srcdir/documentation/doxygen ]; then
   cd $srcdir/documentation/doxygen
-  make PYTHON_EXECUTABLE=${PYTHON}
+  make
   cd $dir
   mv $dir/${docdir}_TMP/html $dir/${docdir}
   if [ -d $dir/${docdir}_TMP/notebooks ]; then


### PR DESCRIPTION
No need to define PYTHON and PYTHON_EXECUTABLE in this script. It is already defined in  the Makefile of the ROOT reference guide. 