### PR TITLE
Don't report a windows build as failed when a PR description quotes the error the PR is fixing

### DIFF
--- a/jenkins/jk-all.bat
+++ b/jenkins/jk-all.bat
@@ -73,7 +73,7 @@ if "%ACTION%" neq "test" (
 if "%ACTION%" neq "build" (
     if "%RUN_TESTS%" == "yes" (
         echo Dumping the full environment ---------------------------------------------------------
-        set
+        set | find /V "ghprbPullLongDescription" | find /V "ghprbPullDescription" | find /V "ghprbPullTitle" | find /V "ghprbCommentBody"
         echo --------------------------------------------------------------------------------------
 
         ctest --no-compress-output -V -S %THIS%/root-test.cmake


### PR DESCRIPTION
Windows CI builds often reports errors even though the build was successful. The reason for this is that the CI script dumps the environment variables in the log, and one of the environment variables contains the description of the PR that is being tested. If the description quotes the error that the PR is fixing (which is a reasonable thing to do), this means that because the PR description contains an error message, the CI build log will contain this error message and when the log is scanned the build will be flagged as a failure even though the error did not happen during the build.

The script dumps the environment twice. The first time the PR description is filtered out, but the second time not. This PR copies the filtering done the first time (line 53) to also be used the second time (line 76).
